### PR TITLE
feature: use subdir template for easy project setup

### DIFF
--- a/SolARAllModules.pro
+++ b/SolARAllModules.pro
@@ -1,0 +1,40 @@
+##
+## @copyright Copyright (c) 2020 B-com http://www.b-com.com/
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+
+CONFIG -= flat
+
+TEMPLATE = subdirs
+
+SUBDIRS = \
+    core/SolARFramework/SolARFramework.pro \
+    core/SolARPipelineManager/SolARPipelineManager.pro \
+    modules/SolARModuleCeres/SolARModuleCeres.pro \
+    modules/SolARModuleFBOW/SolARModuleFBOW.pro \
+    modules/SolARModuleG2O/SolARModuleG2O.pro \
+    modules/SolARModuleNonFreeOpenCV/SolARModuleNonFreeOpenCV.pro \
+    modules/SolARModuleOpenCV/SolARModuleOpenCV.pro \
+    modules/SolARModuleOpenGL/SolARModuleOpenGL.pro \
+    modules/SolARModuleOpenGV/SolARModuleOpenGV.pro \
+    modules/SolARModulePCL/SolARModulePCL.pro \
+    modules/SolARModuleRealSense/SolARModuleRealSense.pro \
+    modules/SolARModuleTools/SolARModuleTools.pro \
+
+
+
+
+
+
+

--- a/SolARAllModulesTests.pro
+++ b/SolARAllModulesTests.pro
@@ -1,0 +1,61 @@
+##
+## @copyright Copyright (c) 2020 B-com http://www.b-com.com/
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+
+CONFIG -= flat
+
+TEMPLATE = subdirs
+
+SUBDIRS = \
+    modules/SolARModuleCeres/tests/Bundler/SolARTestModuleCeresBundler.pro \
+    modules/SolARModuleCeres/tests/SolARTestCeresGlobalBundleAdjustment/SolARTestCeresGlobalBundleAdjustment.pro \
+    modules/SolARModuleFBOW/tests/ClosestKeyframeRetrieval/SolARTestModuleFBOWClosestKeyframeRetrieval.pro \
+    modules/SolARModuleFBOW/tests/SolARFeatureMatchingUsingFBOW/SolARFeatureMatchingUsingFBOW.pro \
+    modules/SolARModuleG2O/tests/SolARTestModuleG2OBundler/SolARTestModuleG2OBundler.pro \
+    modules/SolARModuleG2O/tests/SolARTestModuleG2OGlobalBundleAdjustment/SolARTestModuleG2OGlobalBundleAdjustment.pro \
+    modules/SolARModuleNonFreeOpenCV/tests/SolARDescriptorExtractor/SolARDescriptorExtractorOpenCVNonFreeTest.pro \
+    modules/SolARModuleOpenCV/tests/SolARCameraCalibration/SolARCameraCalibration.pro \
+    modules/SolARModuleOpenCV/tests/SolARDescriptorMatcher/SolARDescriptorMatcherOpenCVTest.pro \
+    modules/SolARModuleOpenCV/tests/SolARDeviceDataLoader/SolARDeviceDataLoaderTest.pro \
+    modules/SolARModuleOpenCV/tests/SolARDeviceDualMarkerCalibration/SolARDeviceDualMarkerCalibrationTest.pro \
+    modules/SolARModuleOpenCV/tests/SolARDevicePoseCorrection/SolARDevicePoseCorrectionTest.pro \
+    modules/SolARModuleOpenCV/tests/SolARFiducialMarker/SolARMarker2DFiducialOpenCVTest.pro \
+    modules/SolARModuleOpenCV/tests/SolARFundamentalMatrixDecomposer/SolARFundamentalMatrixDecomposerOpenCVTest.pro \
+    modules/SolARModuleOpenCV/tests/SolARFundamentalMatrixEstimation/SolARFundamentalMatrixEstimationOpenCVTest.pro \
+    modules/SolARModuleOpenCV/tests/SolARImageConvertor/SolARImageConvertorOpenCVTest.pro \
+    modules/SolARModuleOpenCV/tests/SolARImageLoader/SolARImageLoaderOpenCVTest.pro \
+    modules/SolARModuleOpenCV/tests/SolARMatchesFilter/SolARMatchesFilterTest.pro \
+    modules/SolARModuleOpenCV/tests/SolAROpticalFlow/SolAROpticalFlowOpenCVTest.pro \
+    modules/SolARModuleOpenGL/tests/PointsCloudDisplay/SolARTestModuleOpenGLPointCloudDisplay.pro \
+    modules/SolARModuleOpenGV/tests/SolARTestModuleOpenGVPnP/SolARTestModuleOpenGVPnP.pro \
+    modules/SolARModuleOpenGV/tests/SolARTestModuleOpenGVTriangulation/SolARTestModuleOpenGVTriangulation.pro \
+    modules/SolARModulePCL/tests/SolARTestPCLPointCloudLoader/SolARTestPCLPointCloudLoader.pro \
+    modules/SolARModuleRealSense/tests/SolARTestRealSenseRGBDCamera/SolARTestRealSenseRGBDCamera.pro \
+    modules/SolARModuleTools/SolARModuleTools.pro \
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/SolARAllModulesTests.pro
+++ b/SolARAllModulesTests.pro
@@ -43,7 +43,6 @@ SUBDIRS = \
     modules/SolARModuleOpenGV/tests/SolARTestModuleOpenGVTriangulation/SolARTestModuleOpenGVTriangulation.pro \
     modules/SolARModulePCL/tests/SolARTestPCLPointCloudLoader/SolARTestPCLPointCloudLoader.pro \
     modules/SolARModuleRealSense/tests/SolARTestRealSenseRGBDCamera/SolARTestRealSenseRGBDCamera.pro \
-    modules/SolARModuleTools/SolARModuleTools.pro \
 
 
 

--- a/SolARAllSamples.pro
+++ b/SolARAllSamples.pro
@@ -1,0 +1,46 @@
+##
+## @copyright Copyright (c) 2020 B-com http://www.b-com.com/
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+
+CONFIG -= flat
+
+TEMPLATE = subdirs
+ 
+SUBDIRS = \
+    samples\FiducialMarker\StandAlone\SolARFiducialMarkerSampleStandAlone.pro \
+    samples\FiducialMarker\Plugin\PipelineFiducialMarker.pro \
+    samples\NaturalImageMarker\Multithread\SolARNaturalImageMarkerMT.pro \
+    samples\NaturalImageMarker\Plugin\PipelineNaturalImageMarker.pro \
+    samples\NaturalImageMarker\StandAlone\SolARNaturalImageMarkerStandAlone.pro \
+    samples\Sample-DepthCamera\StandAlone\SolARDepthCameraSampleStandAlone.pro \
+    samples\Sample-Mapping\MapExtension\StandAlone\SolARMapExtensionStandAlone.pro \
+    samples\Sample-Mapping\MapFusion\floatingMapFusionStandAlone\SolARfloatingMapFusionStandAlone.pro \
+    samples\Sample-Mapping\MapFusion\localMapFusionStandAlone\SolARLocalMapFusionStandAlone.pro \
+    samples\Sample-Mapping\Mapping\Multi\SolARMappingMulti.pro \
+    samples\Sample-Mapping\Mapping\SolARMappingPipeline\SolARMappingPipeline.pro \
+    samples\Sample-Mapping\Mapping\SolARMappingPipelineMulti\SolARMappingPipelineMulti.pro \
+    samples\Sample-Mapping\Mapping\StandAlone\SolARMappingStandAlone.pro \
+    samples\Sample-Mapping\MapViz\SolARMapViz.pro \
+    samples\Sample-Slam\Mono\SolARSlamSampleMono.pro \
+    samples\Sample-Slam\Multi\SolARSlamSampleMulti.pro \
+    samples\Sample-Slam\Plugin\PipelineSlam.pro \
+    samples\Sample-Triangulation\StandAlone\SolARTriangulationSample.pro \
+
+
+
+
+
+
+

--- a/SolARAllSamplesTests.pro
+++ b/SolARAllSamplesTests.pro
@@ -1,0 +1,29 @@
+##
+## @copyright Copyright (c) 2020 B-com http://www.b-com.com/
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+
+CONFIG -= flat
+
+TEMPLATE = subdirs
+ 
+SUBDIRS = \
+    samples/FiducialMarker/Plugin/tests/TestFiducialMarkerPipeline/TestFiducialMarkerPlugin.pro \
+    samples/NaturalImageMarker/Plugin/tests/TestNaturalImageMarkerPipeline/TestNaturalImageMarkerPlugin.pro \
+    samples/Sample-Mapping/Mapping/SolARMappingPipeline/tests/TestSolARMappingPipeline/TestSolARMappingPipeline.pro \
+    samples/Sample-Mapping/Mapping/SolARMappingPipelineMulti/tests/TestSolARMappingPipelineMulti/TestSolARMappingPipelineMulti.pro \
+    samples/Sample-Slam/Plugin/tests/TestSlamPipeline/TestSlamPlugin.pro \
+
+
+


### PR DESCRIPTION
With these .pro files, several projects can be imported
at once in QtCreator.
It should no longer be necessary to manually import all .pro files when starting to work with SolAR.
It should also work to create Visual Studio solutions (qmake -tp vc -r, c.f. https://wiki.qt.io/SUBDIRS_-_handling_dependencies)
This CL adds 4 sets, to create 4 QtCreator sessions:

- Modules
- Modules tests
- Samples
- Sample tests


