### PR TITLE
feat: add install_deps_all target

### DIFF
--- a/SolARAllModules.pro
+++ b/SolARAllModules.pro
@@ -50,10 +50,15 @@ win32 {
 }
 
 
- 
+
   # what subproject depends on others
   SolARModuleNonFreeOpenCV.depends = SolARModuleOpenCV
 
+# Add install_deps_all target that recursively calls install_deps
+# on submodules
+install_deps_all.CONFIG += recursive
+install_deps_all.recurse_target = install_deps
+QMAKE_EXTRA_TARGETS += install_deps_all
 
 
 

--- a/SolARAllModulesTests.pro
+++ b/SolARAllModulesTests.pro
@@ -53,7 +53,11 @@ win32 {
 		modules/SolARModuleRealSense/tests/SolARTest_ModuleRealSense_RGBDCamera/SolARTest_ModuleRealSense_RGBDCamera.pro
 }
 
-
+# Add install_deps_all target that recursively calls install_deps
+# on submodules
+install_deps_all.CONFIG += recursive
+install_deps_all.recurse_target = install_deps
+QMAKE_EXTRA_TARGETS += install_deps_all
 
 
 

--- a/SolARAllPipelineTests.pro
+++ b/SolARAllPipelineTests.pro
@@ -25,5 +25,9 @@ SUBDIRS = \
     samples/Sample-Mapping/Mapping/SolARPipeline_Mapping_Multi/tests/SolARPipelineTest_Mapping_Multi/SolARPipelineTest_Mapping_Multi.pro \
     samples/Sample-Slam/SolARPipeline_SLAM/tests/SolARPipelineTest_SLAM/SolARPipelineTest_SLAM.pro
 
-
+# Add install_deps_all target that recursively calls install_deps
+# on submodules
+install_deps_all.CONFIG += recursive
+install_deps_all.recurse_target = install_deps
+QMAKE_EXTRA_TARGETS += install_deps_all
 

--- a/SolARAllPipelines.pro
+++ b/SolARAllPipelines.pro
@@ -25,5 +25,9 @@ SUBDIRS = \
     samples/Sample-Mapping/Mapping/SolARPipeline_Mapping_Multi/SolARPipeline_Mapping_Multi.pro \
     samples/Sample-Slam/SolARPipeline_SLAM/SolARPipeline_SLAM.pro \
 
-
+# Add install_deps_all target that recursively calls install_deps
+# on submodules
+install_deps_all.CONFIG += recursive
+install_deps_all.recurse_target = install_deps
+QMAKE_EXTRA_TARGETS += install_deps_all
 

--- a/SolARAllSamples.pro
+++ b/SolARAllSamples.pro
@@ -33,7 +33,11 @@ SUBDIRS = \
     samples/Sample-Triangulation/SolARSample_Triangulation_Mono/SolARSample_Triangulation_Mono.pro \
     samples/Sample-DepthCamera/SolARSample_DepthCamera_Mono/SolARSample_DepthCamera_Mono.pro
 
-
+# Add install_deps_all target that recursively calls install_deps
+# on submodules
+install_deps_all.CONFIG += recursive
+install_deps_all.recurse_target = install_deps
+QMAKE_EXTRA_TARGETS += install_deps_all
 
 
 


### PR DESCRIPTION
Adds a install_deps_all target in subdirs .pro files
i order to be able to add a build step in QTCreator that
recursevely calls install_deps target on all submodules.