### PR TITLE
Use "." as submodules tracking branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,55 +1,55 @@
 [submodule "core/SolARFramework"]
 	path = core/SolARFramework
 	url = https://github.com/SolarFramework/SolARFramework
-	branch = 0.9.3
+	branch = .
 [submodule "core/SolARFrameworkGRPCRemote"]
 	path = core/SolARFrameworkGRPCRemote
 	url = https://github.com/SolarFramework/SolARFrameworkGRPCRemote
-	branch = 0.9.3
+	branch = .
 [submodule "modules/SolARModuleTools"]
 	path = modules/SolARModuleTools
 	url = https://github.com/SolarFramework/SolARModuleTools
-	branch = 0.9.3
+	branch = .
 [submodule "samples/Sample-Slam"]
 	path = samples/Sample-Slam
 	url = https://github.com/SolarFramework/Sample-Slam
-	branch = 0.9.3
+	branch = .
 [submodule "modules/SolARModuleOpenCV"]
 	path = modules/SolARModuleOpenCV
 	url = https://github.com/SolarFramework/SolARModuleOpenCV
-	branch = 0.9.3
+	branch = .
 [submodule "modules/SolARModuleOpenGV"]
 	path = modules/SolARModuleOpenGV
 	url = https://github.com/SolarFramework/SolARModuleOpenGV
-	branch = 0.9.3
+	branch = .
 [submodule "modules/SolARModuleOpenGL"]
 	path = modules/SolARModuleOpenGL
 	url = https://github.com/SolarFramework/SolARModuleOpenGL
-	branch = 0.9.3
+	branch = .
 [submodule "modules/SolARModuleNonFreeOpenCV"]
 	path = modules/SolARModuleNonFreeOpenCV
 	url = https://github.com/SolarFramework/SolARModuleNonFreeOpenCV
-	branch = 0.9.3
+	branch = .
 [submodule "modules/SolARModuleFBOW"]
 	path = modules/SolARModuleFBOW
 	url = https://github.com/SolarFramework/SolARModuleFBOW
-	branch = 0.9.3
+	branch = .
 [submodule "modules/SolARModuleCeres"]
 	path = modules/SolARModuleCeres
 	url = https://github.com/SolarFramework/SolARModuleCeres
-	branch = 0.9.3
+	branch = .
 [submodule "modules/SolARModuleG2O"]
 	path = modules/SolARModuleG2O
 	url = https://github.com/SolarFramework/SolARModuleG2O
-	branch = 0.9.3
+	branch = .
 [submodule "samples/Sample-Triangulation"]
 	path = samples/Sample-Triangulation
 	url = https://github.com/SolarFramework/Sample-Triangulation
-	branch = 0.9.3
+	branch = .
 [submodule "core/SolARPipelineManager"]
 	path = core/SolARPipelineManager
 	url = https://github.com/SolarFramework/SolARPipelineManager
-	branch = 0.9.3
+	branch = .
 [submodule "plugin/unity/SolARUnityPlugin"]
 	path = plugin/unity/SolARUnityPlugin
 	url = https://github.com/SolarFramework/SolARUnityPlugin
@@ -57,32 +57,32 @@
 [submodule "modules/SolARModuleRealSense"]
 	path = modules/SolARModuleRealSense
 	url = https://github.com/SolarFramework/SolARModuleRealSense.git
-	branch = 0.9.3
+	branch = .
 [submodule "modules/SolARModulePCL"]
 	path = modules/SolARModulePCL
 	url = https://github.com/SolarFramework/SolARModulePCL.git
-	branch = 0.9.3
+	branch = .
 [submodule "samples/Sample-DepthCamera"]
 	path = samples/Sample-DepthCamera
 	url = https://github.com/SolarFramework/Sample-DepthCamera.git
-	branch = 0.9.3
+	branch = .
 [submodule "samples/Sample-FiducialMarker"]
 	path = samples/Sample-FiducialMarker
 	url = https://github.com/SolarFramework/Sample-FiducialMarker
-	branch = 0.9.3
+	branch = .
 [submodule "samples/Sample-Mapping"]
 	path = samples/Sample-Mapping
 	url = https://github.com/SolarFramework/Sample-Mapping
-	branch = 0.9.3
+	branch = .
 [submodule "samples/Sample-NaturalImageMarker"]
 	path = samples/Sample-NaturalImageMarker
 	url = https://github.com/SolarFramework/Sample-NaturalImageMarker
-	branch = 0.9.3
+	branch = .
 [submodule "samples/Sample-Relocalization"]
 	path = samples/Sample-Relocalization
 	url = https://github.com/SolarFramework/Sample-Relocalization
-	branch = 0.9.3
+	branch = .
 [submodule "samples/Sample-MapUpdate"]
 	path = samples/Sample-MapUpdate
 	url = https://github.com/SolarFramework/Sample-MapUpdate.git
-	branch = 0.9.3
+	branch = .


### PR DESCRIPTION
- All tracking branch were set to 0.9.3, which the same as the
current branch of SolAR repo.
- This enables to merge the .gitmodules file to develop
without having to worry about ignoring it, and manually
bring the modification in develop's .gitsubmodules.